### PR TITLE
Protocol based js<->clj key value mapping

### DIFF
--- a/src/cljs_bean/core.cljs
+++ b/src/cljs_bean/core.cljs
@@ -727,14 +727,14 @@
     (prop->key [_ prop] prop)
     (transform [ctx v _ _ _] (->val ctx v))))
 
-(deftype K-Transform [key->prop' prop->key']
+(deftype ^:private K-Transform [key->prop' prop->key']
   BeanContext
   (keywords? [_] (identical? key->prop' keyword))
   (key->prop [_ x] (key->prop' x))
   (prop->key [_ prop] (prop->key' prop))
   (transform [ctx v _ _ _] (->val ctx v)))
 
-(deftype V-Transform [transform']
+(deftype ^:private V-Transform [transform']
   BeanContext
   (keywords? [_] false)
   (key->prop [_ x] x)
@@ -743,7 +743,7 @@
     (if-some [transformed (transform' v)] transformed
       #_else (->val ctx v))))
 
-(deftype KV-Transform [key->prop' prop->key' transform']
+(deftype ^:private KV-Transform [key->prop' prop->key' transform']
   BeanContext
   (keywords? [_] (identical? prop->key' keyword))
   (key->prop [_ x] (key->prop' x))

--- a/test/cljs_bean/core_test.cljs
+++ b/test/cljs_bean/core_test.cljs
@@ -1263,7 +1263,7 @@
 
 (defrecord Foo [x])
 
-(defn foo-transform [x]
+(defn foo-transform [x _ctx]
   (when (instance? Foo x)
     (:x x)))
 

--- a/test/cljs_bean/core_test.cljs
+++ b/test/cljs_bean/core_test.cljs
@@ -1263,7 +1263,7 @@
 
 (defrecord Foo [x])
 
-(defn foo-transform [x _ctx]
+(defn foo-transform [x]
   (when (instance? Foo x)
     (:x x)))
 


### PR DESCRIPTION
This PR introduces the `BeanContext`, mainly for use in our `malli-ts` library to enable low overhead ([simple benchmarks](https://github.com/flowyourmoney/malli-ts/actions/runs/3504076719/jobs/5869524831#step:7:185) show ~10%) mapping of custom/namespaced keywords to javascript properties.

See also:

- https://github.com/flowyourmoney/malli-ts/pull/9
- [Example of such a mapping in malli-ts unit tests](https://github.com/flowyourmoney/malli-ts/blob/41dd987f86bb0ebe7ea1cd86dd63df81bd28d499/test/malli_ts/data_mapping_test.cljs#L23)
  `[:order-item/test-dummy {::mts/clj<->js {:prop "TESTDummyXYZ"}} string?]`

---

We have 2 reasons to make this a protocol:

1. Remove the overhead of allocating 3 partials on every access (`prop->key`, `key->prop`, `transform`)
2. Add (a lot) more context to `transform`, allowing us to lookup the malli schema for the key that needs to be transformed

To remain backwards compatible, we didn't change the `transform` option signature.
Instead if a call to `->clj` is supplied with the `:context` option, it's used instead.

The transform `(transform [_ v p k n] ...` gets called with:
- value
- js property
- cljs keyword
- nth index (array/vector access) or `nil` (map access)

In `malli-ts` we create a context implementation that wraps a "property/keyword → malli `:map` schema mapping" (also following `:ref`s) and use the additional context to find the nested schema defined keyword mapping. _Perhaps in the future we will add support for coercing values lazily_.


The default options have a static reified instance, for example for the default keywordize behavior:

```clojure
(def ^:private keywordize-ctx
  (reify BeanContext
    (keywords? [_] true)
    (key->prop [_ x] (default-key->prop x))
    (prop->key [_ prop] (keyword prop))
    (transform [ctx v _ _ _] (->val ctx v))))
```